### PR TITLE
Additional booleans for longitudinal and lateral safe states division

### DIFF
--- a/ad_rss/generated/include/ad/rss/state/ProperResponse.hpp
+++ b/ad_rss/generated/include/ad/rss/state/ProperResponse.hpp
@@ -133,9 +133,24 @@ struct ProperResponse
   ::ad::rss::world::TimeIndex timeIndex{0u};
 
   /*!
-   * Flag to indicate if the state is longitudinal safe.
+   * Flag to indicate if the state is safe both longitudinally and laterally.
    */
   bool isSafe{false};
+
+  /*!
+   * Flag to indicate if the state is safe longitudinally.
+   */
+  bool isSafeLongitudinal{false};
+
+  /*!
+   * Flag to indicate if the state is safe laterally to the right.
+   */
+  bool isSafeLateralRight{false};
+
+  /*!
+   * Flag to indicate if the state is safe laterally to the left.
+   */
+  bool isSafeLateralLeft{false};
 
   /*!
    * List of dangerous objects.

--- a/ad_rss/src/core/RssResponseResolving.cpp
+++ b/ad_rss/src/core/RssResponseResolving.cpp
@@ -36,6 +36,9 @@ bool RssResponseResolving::provideProperResponse(state::RssStateSnapshot const &
   {
     response.timeIndex = currentStateSnapshot.timeIndex;
     response.isSafe = true;
+    response.isSafeLongitudinal = true;
+    response.isSafeLateralRight = true;
+    response.isSafeLateralLeft = true;
     response.dangerousObjects.clear();
     response.longitudinalResponse = state::LongitudinalResponse::None;
     response.lateralResponseLeft = state::LateralResponse::None;
@@ -84,6 +87,10 @@ bool RssResponseResolving::provideProperResponse(state::RssStateSnapshot const &
 
     for (auto const &currentState : currentStateSnapshot.individualResponses)
     {
+      response.isSafeLongitudinal &= currentState.longitudinalState.isSafe;
+      response.isSafeLateralRight &= currentState.lateralStateRight.isSafe;
+      response.isSafeLateralLeft &= currentState.lateralStateLeft.isSafe;
+
       if (isDangerous(currentState))
       {
         response.isSafe = false;


### PR DESCRIPTION
#### Description

Additional Boolean flags have been added in order to allow dividing safety states in RSS evaluation report generator. Those accompanying changes live [here](https://github.com/tier4/rss_evaluation_tools/tree/bartek-kc/multiple-safe-states) and were requested in Jira tickets [AJD-586](https://tier4.atlassian.net/browse/AJD-586) and [AJD-609](https://tier4.atlassian.net/browse/AJD-609).

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Library version:** ROS galactic

#### Possible Drawbacks

None.
