### PR TITLE
Configure dependency management for rosdep & colcon

### DIFF
--- a/ad_rss/package.xml
+++ b/ad_rss/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>ad_rss</name>
+  <version>4.5.2</version>
+  <description>C++ Library for Responsibility Sensitive Safety</description>
+
+  <maintainer email="adam.gotlib@robotec.ai">Adam Gotlib</maintainer>
+  <author email="bernd.gassmann@intel.com">Bernd Gassmann</author>
+  <license>GPLv2</license>
+
+  <depend>ad_physics</depend>
+  <depend>spdlog</depend>
+  <depend>boost</depend>
+
+  <test_depend>gtest</test_depend>
+</package>


### PR DESCRIPTION
- add `package.xml` to `ad_rss` to ensure dependencies are properly managed by `rosdep` (the list of dependencies comes from [upstream documentation](https://intel.github.io/ad-rss-lib/BUILDING/index.html));
- add <s>`AMENT_IGNORE`</s>`COLCON_IGNORE` files to `ad_rss_map_integration` to exclude it from build (this allows to avoid on one hand unnecessarily extending the build time, on the other polluting the system by installing additional dependencies).

It's assumed this fork will only be used to provide `ad_rss` dependency for other packages. If `ad_rss_map_integration` is going to be needed as well, a better solution would be to provide `package.xml` for it as well.