### PR TITLE
Clean up build warnings related to Boost and colcon

### DIFF
--- a/ad_rss/CMakeLists.txt
+++ b/ad_rss/CMakeLists.txt
@@ -35,6 +35,17 @@ find_package(spdlog REQUIRED CONFIG)
 
 include(generated/ad_rss.cmake)
 
+# Surpress warnings coming from Boost
+# See: https://stackoverflow.com/questions/66906613/how-to-silence-internal-boost-deprecated-messages
+add_definitions("-DBOOST_ALLOW_DEPRECATED_HEADERS")
+
+# Ignore additional variables added when building with colcon
+# See: https://stackoverflow.com/questions/36451368/get-rid-of-cmake-warning-manually-specified-variables-were-not-used-by-the-proj
+set(IGNORED_VARIABLES
+  ${CATKIN_INSTALL_INTO_PREFIX_ROOT}
+  ${CATKIN_SYMLINK_INSTALL}
+)
+
 add_library(${PROJECT_NAME}
   ${ad_rss_GENERATED_SOURCES}
   ${CMAKE_CURRENT_SOURCE_DIR}/src/core/RssCheck.cpp


### PR DESCRIPTION
This PR removes the following warnings when building with `colcon`:

```
--- stderr: ad_rss                                
CMake Warning:
  Manually-specified variables were not used by the project:

    CATKIN_INSTALL_INTO_PREFIX_ROOT
    CATKIN_SYMLINK_INSTALL


In file included from /usr/include/boost/math/tools/cxx03_warn.hpp:9,
                 from /usr/include/boost/math/constants/constants.hpp:11,
                 from /usr/include/boost/geometry/util/math.hpp:29,
                 from /usr/include/boost/geometry/core/radian_access.hpp:33,
                 from /usr/include/boost/geometry/geometry.hpp:51,
                 from /usr/include/boost/geometry.hpp:17,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/include/ad/rss/unstructured/Geometry.hpp:15,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/src/core/RssResponseResolving.cpp:13:
/usr/include/boost/detail/no_exceptions_support.hpp:17:1: note: ‘#pragma message: This header is deprecated. Use <boost/core/no_exceptions_support.hpp> instead.’
   17 | BOOST_HEADER_DEPRECATED("<boost/core/no_exceptions_support.hpp>")
      | ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/boost/math/tools/cxx03_warn.hpp:9,
                 from /usr/include/boost/math/constants/constants.hpp:11,
                 from /usr/include/boost/geometry/util/math.hpp:29,
                 from /usr/include/boost/geometry/core/radian_access.hpp:33,
                 from /usr/include/boost/geometry/geometry.hpp:51,
                 from /usr/include/boost/geometry.hpp:17,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/include/ad/rss/unstructured/Geometry.hpp:15,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/src/unstructured/TrajectoryCommon.hpp:18,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/src/unstructured/TrajectoryCommon.cpp:13:
/usr/include/boost/detail/no_exceptions_support.hpp:17:1: note: ‘#pragma message: This header is deprecated. Use <boost/core/no_exceptions_support.hpp> instead.’
   17 | BOOST_HEADER_DEPRECATED("<boost/core/no_exceptions_support.hpp>")
      | ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/boost/math/tools/cxx03_warn.hpp:9,
                 from /usr/include/boost/math/constants/constants.hpp:11,
                 from /usr/include/boost/geometry/util/math.hpp:29,
                 from /usr/include/boost/geometry/core/radian_access.hpp:33,
                 from /usr/include/boost/geometry/geometry.hpp:51,
                 from /usr/include/boost/geometry.hpp:17,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/include/ad/rss/unstructured/Geometry.hpp:15,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/src/unstructured/TrajectoryCommon.hpp:18,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/src/unstructured/TrajectoryVehicle.hpp:17,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/src/unstructured/TrajectoryVehicle.cpp:12:
/usr/include/boost/detail/no_exceptions_support.hpp:17:1: note: ‘#pragma message: This header is deprecated. Use <boost/core/no_exceptions_support.hpp> instead.’
   17 | BOOST_HEADER_DEPRECATED("<boost/core/no_exceptions_support.hpp>")
      | ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/boost/math/tools/cxx03_warn.hpp:9,
                 from /usr/include/boost/math/constants/constants.hpp:11,
                 from /usr/include/boost/geometry/util/math.hpp:29,
                 from /usr/include/boost/geometry/core/radian_access.hpp:33,
                 from /usr/include/boost/geometry/geometry.hpp:51,
                 from /usr/include/boost/geometry.hpp:17,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/include/ad/rss/unstructured/Geometry.hpp:15,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/src/situation/RssUnstructuredSceneChecker.hpp:19,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/src/situation/RssUnstructuredSceneChecker.cpp:9:
/usr/include/boost/detail/no_exceptions_support.hpp:17:1: note: ‘#pragma message: This header is deprecated. Use <boost/core/no_exceptions_support.hpp> instead.’
   17 | BOOST_HEADER_DEPRECATED("<boost/core/no_exceptions_support.hpp>")
      | ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/boost/math/tools/cxx03_warn.hpp:9,
                 from /usr/include/boost/math/constants/constants.hpp:11,
                 from /usr/include/boost/geometry/util/math.hpp:29,
                 from /usr/include/boost/geometry/core/radian_access.hpp:33,
                 from /usr/include/boost/geometry/geometry.hpp:51,
                 from /usr/include/boost/geometry.hpp:17,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/include/ad/rss/unstructured/Geometry.hpp:15,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/src/unstructured/TrajectoryCommon.hpp:18,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/src/unstructured/TrajectoryPedestrian.hpp:15,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/src/unstructured/TrajectoryPedestrian.cpp:12:
/usr/include/boost/detail/no_exceptions_support.hpp:17:1: note: ‘#pragma message: This header is deprecated. Use <boost/core/no_exceptions_support.hpp> instead.’
   17 | BOOST_HEADER_DEPRECATED("<boost/core/no_exceptions_support.hpp>")
      | ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/boost/math/tools/cxx03_warn.hpp:9,
                 from /usr/include/boost/math/constants/constants.hpp:11,
                 from /usr/include/boost/geometry/util/math.hpp:29,
                 from /usr/include/boost/geometry/core/radian_access.hpp:33,
                 from /usr/include/boost/geometry/geometry.hpp:51,
                 from /usr/include/boost/geometry.hpp:17,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/include/ad/rss/unstructured/Geometry.hpp:15,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/src/unstructured/Geometry.cpp:12:
/usr/include/boost/detail/no_exceptions_support.hpp:17:1: note: ‘#pragma message: This header is deprecated. Use <boost/core/no_exceptions_support.hpp> instead.’
   17 | BOOST_HEADER_DEPRECATED("<boost/core/no_exceptions_support.hpp>")
      | ^~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/boost/math/tools/cxx03_warn.hpp:9,
                 from /usr/include/boost/math/constants/constants.hpp:11,
                 from /usr/include/boost/geometry/util/math.hpp:29,
                 from /usr/include/boost/geometry/core/radian_access.hpp:33,
                 from /usr/include/boost/geometry/geometry.hpp:51,
                 from /usr/include/boost/geometry.hpp:17,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/include/ad/rss/unstructured/Geometry.hpp:15,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/src/core/../situation/RssUnstructuredSceneChecker.hpp:19,
                 from /home/goldob/rss_ws/src/external/ad_rss_lib/ad_rss/src/core/RssSituationChecking.cpp:14:
/usr/include/boost/detail/no_exceptions_support.hpp:17:1: note: ‘#pragma message: This header is deprecated. Use <boost/core/no_exceptions_support.hpp> instead.’
   17 | BOOST_HEADER_DEPRECATED("<boost/core/no_exceptions_support.hpp>")
      | ^~~~~~~~~~~~~~~~~~~~~~~
---
Finished <<< ad_rss [18.0s]
```

These are of two kinds:
- warnings related to additional variables added by `colcon` (see https://github.com/RobotecAI/map/pull/2)
- warnings related to internal issues with Boost (see [this thread](https://stackoverflow.com/questions/66906613/how-to-silence-internal-boost-deprecated-messages))