### PR TITLE
Update copyright on file added by Robotec.ai

### DIFF
--- a/ad_rss/include/ad/rss/logging/ExtendedSituationData.hpp
+++ b/ad_rss/include/ad/rss/logging/ExtendedSituationData.hpp
@@ -1,6 +1,6 @@
 // ----------------- BEGIN LICENSE BLOCK ---------------------------------
 //
-// Copyright (C) 2018-2023 Intel Corporation and Robotec.ai
+// Copyright (C) 2018-2023 TIER IV and Robotec.ai
 //
 // SPDX-License-Identifier: LGPL-2.1-only
 //


### PR DESCRIPTION
As described by Yamasaki-san:

> Copy right should not be Intel on a code of the Robotec fork , because Robotec developed the code and merged into the Robotec fork under TIER IV project. ( so it should be TIER IV )